### PR TITLE
Added the ability to specify a skin for all forms via the config file or for a single form.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -119,7 +119,13 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                     ->setInfo("The location of the script that handles file uploads in the Flash dialog window.")
                 ->end()
-            ->end()   
+            ->end()
+			->children()
+                ->scalarNode('skin')
+                    ->defaultNull()
+                    ->setInfo("The location and name of the skin to be used.")
+                ->end()
+            ->end()
         ;
 
         return $treeBuilder;

--- a/DependencyInjection/TrsteelCkeditorExtension.php
+++ b/DependencyInjection/TrsteelCkeditorExtension.php
@@ -45,6 +45,7 @@ class TrsteelCkeditorExtension extends Extension
         $container->setParameter('trsteel_ckeditor.ckeditor.filebrowser_image_upload_url', $config['filebrowser_image_upload_url']);
         $container->setParameter('trsteel_ckeditor.ckeditor.filebrowser_flash_browse_url', $config['filebrowser_flash_browse_url']);
         $container->setParameter('trsteel_ckeditor.ckeditor.filebrowser_flash_upload_url', $config['filebrowser_flash_upload_url']);
+		$container->setParameter('trsteel_ckeditor.ckeditor.skin', $config['skin']);
     }
 
     private function getDefaultGroups()

--- a/Form/Type/CkeditorType.php
+++ b/Form/Type/CkeditorType.php
@@ -62,6 +62,7 @@ class CkeditorType extends AbstractType
             ->setAttribute('filebrowser_image_upload_url', $options['filebrowser_image_upload_url'])
             ->setAttribute('filebrowser_flash_browse_url', $options['filebrowser_flash_browse_url'])
             ->setAttribute('filebrowser_flash_upload_url', $options['filebrowser_flash_upload_url'])
+			->setAttribute('skin', $options['skin'])
         ;
     }
     
@@ -107,6 +108,7 @@ class CkeditorType extends AbstractType
             ->set('filebrowser_image_upload_url', $form->getAttribute('filebrowser_image_upload_url'))
             ->set('filebrowser_flash_browse_url', $form->getAttribute('filebrowser_flash_browse_url'))
             ->set('filebrowser_flash_upload_url', $form->getAttribute('filebrowser_flash_upload_url'))
+			->set('skin', $form->getAttribute('skin'))
         ;
     }
     
@@ -130,7 +132,8 @@ class CkeditorType extends AbstractType
             'filebrowser_image_browse_url' => $this->container->getParameter('trsteel_ckeditor.ckeditor.filebrowser_image_browse_url'),
             'filebrowser_image_upload_url' => $this->container->getParameter('trsteel_ckeditor.ckeditor.filebrowser_image_upload_url'),
             'filebrowser_flash_browse_url' => $this->container->getParameter('trsteel_ckeditor.ckeditor.filebrowser_flash_browse_url'),
-            'filebrowser_flash_upload_url' => $this->container->getParameter('trsteel_ckeditor.ckeditor.filebrowser_flash_upload_url'),            
+            'filebrowser_flash_upload_url' => $this->container->getParameter('trsteel_ckeditor.ckeditor.filebrowser_flash_upload_url'),
+			'skin'                         => $this->container->getParameter('trsteel_ckeditor.ckeditor.skin'),
         );
     }
     

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -41,6 +41,9 @@
             {% if filebrowser_flash_upload_url is not null %}
                 filebrowserFlashUploadUrl: '{{ filebrowser_flash_upload_url }}',
             {% endif %}
+			{% if skin is not null %}
+                skin: '{{ skin }}',
+            {% endif %}
             toolbar: {{ toolbar | json_encode | raw }}
         });
     {% endautoescape %}

--- a/Tests/Form/CkeditorTypeTest.php
+++ b/Tests/Form/CkeditorTypeTest.php
@@ -421,5 +421,20 @@ class CkeditorTypeTest extends TypeTestCase
         $filebrowserFlashUploadUrl = $view->get('filebrowser_flash_upload_url');
         
         $this->assertEquals($filebrowserFlashUploadUrl, '/myfilebrowser/uploads');
-    }    
+    }
+	
+	/**
+     * Checks skin property
+     */
+    public function testSkin()
+    {
+        $form = $this->factory->create('ckeditor', null, array(
+            'skin' => 'myskin,/skins/myskin/',
+        ));
+        
+        $view = $form->createView();
+        $skin = $view->get('skin');
+        
+        $this->assertEquals($skin, 'myskin,/skins/myskin/');
+    }
 }


### PR DESCRIPTION
The current default skin is within the Ckeditor bundle which prevents the user from modifying or replacing it.

I've added a skin config item, which can be set either via the config file or for a specific form, that allows the user to specify a skin provided elsewhere.

This config setting currently passes it's value straight to the CKEDITOR.replace method and so should be set with a value as explained in the [relevant CKEditor docs](http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html#.skin).

i.e. 'myskin,/bundles/myeditor/skins/myskin/'
