### PR TITLE
Setting CKEditor BASEPATH so form can be loaded by Ajax

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -4,6 +4,12 @@
 {% spaceless %}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
 
+    <script type="text/javascript">
+    {% autoescape true js %}
+        var CKEDITOR_BASEPATH = '/bundles/trsteelckeditor/';
+        {% endautoescape %}
+    </script>
+
     <script type="text/javascript" src="{{ asset('bundles/trsteelckeditor/ckeditor.js') }}"></script>
     <script type="text/javascript">
     {% autoescape true js %}


### PR DESCRIPTION
I had a problem loading a CKEditor form via an Ajax call. The form worked fine loaded straight into a page but if I loaded the template in via an Ajax call then CKEditor would try to load its JS and CSS from the wrong path and would break.

This issue has been found in another CKEditor bundle (https://github.com/egeloen/IvoryCKEditorBundle/issues/2) so the fix is basically the same here.
