### PR TITLE
Change order of array_merge to allow override template

### DIFF
--- a/DependencyInjection/TrsteelCkeditorExtension.php
+++ b/DependencyInjection/TrsteelCkeditorExtension.php
@@ -26,8 +26,8 @@ class TrsteelCkeditorExtension extends Extension
         $loader->load('services.yml');
 
         $container->setParameter('twig.form.resources', array_merge(
-            $container->getParameter('twig.form.resources'),
-            array('TrsteelCkeditorBundle:Form:ckeditor_widget.html.twig')
+            array('TrsteelCkeditorBundle:Form:ckeditor_widget.html.twig'),
+            $container->getParameter('twig.form.resources')
         ));
         
         $config['toolbar_groups'] = array_merge($this->getDefaultGroups(), $config['toolbar_groups']);


### PR DESCRIPTION
This allows us to override the widget block template using standard twig form resources:

```
twig:
    debug:            %kernel.debug%
    strict_variables: %kernel.debug%
    form:
        resources:
            - 'AcmeBundle:Form:fields.html.twig'
```
