### PR TITLE
Fix "*" in composer definition in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ```js
 {
     "require": {
-        "Trsteel/ckeditor-bundle": "*"
+        "Trsteel/ckeditor-bundle": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
"*" will download version 1.0 of this bundle which is not working with Symfony 2.1.
