### PR TITLE
Base path config breaks asset url rewrite

### DIFF
--- a/DependencyInjection/TrsteelCkeditorExtension.php
+++ b/DependencyInjection/TrsteelCkeditorExtension.php
@@ -36,6 +36,9 @@ class TrsteelCkeditorExtension extends Extension
             $plugin['path'] = '/'.rtrim(ltrim($plugin['path'], '/'), '/').'/';
         }
 
+        // Ensure no leading slash on base path
+        $config['base_path'] = ltrim($config['base_path'], '/');
+
         $container->setParameter('trsteel_ckeditor.form.type.class', $config['class']);
         $container->setParameter('trsteel_ckeditor.ckeditor.transformers', $config['transformers']);
         $container->setParameter('trsteel_ckeditor.ckeditor.toolbar', $config['toolbar']);

--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -6,7 +6,7 @@
 
     <script type="text/javascript">
     {% autoescape true js %}
-        var CKEDITOR_BASEPATH = '{{ app.request.basePath ~ base_path }}';
+        var CKEDITOR_BASEPATH = '{{ app.request.basePath ~ '/' ~ base_path }}';
     {% endautoescape %}
     </script>
 


### PR DESCRIPTION
Before the last PR #31 was merged, the JS variable was set using `/bundles/trsteelckeditor/` and the twig asset() call using `bundles/trsteelckeditor/` -- Note the lack of leading slash on the latter.

With the new functionality, the path contains the leading slash, is assumed by `asset()` as absolute, and is not rewritten properly.

This PR strips any leading slash during container construction when setting parameters, and then assumes there is no leading slash in the widget template -- fixing the BC break and still supporting the new functionality.

Note: It does not, however, cover the use-case where the user actually wants an absolute base path. But that wasn't supported before, either, since CKEDITOR_BASEPATH gets appended to the application's base path in the javascript of the widget template.
