### PR TITLE
Add instance configuration into a rawConfig instance property

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -19,7 +19,8 @@
             {% endif %}
             {% set plugins = plugins ~ name %}
         {% endfor %}
-        CKEDITOR.replace("{{ id }}",{
+
+        var trsteelConfig = {
             {% if width is not null %}
                 width: '{{ width }}',
             {% endif %}
@@ -111,7 +112,11 @@
                 customConfig: '{{ asset(custom_config) }}',
             {% endif %}
             toolbar: {{ toolbar | json_encode | raw }}
-        });
+        };
+
+        CKEDITOR.replace("{{ id }}", trsteelConfig);
+        CKEDITOR.instances["{{ id }}"].rawConfig = trsteelConfig;
+
     {% endautoescape %}
     </script>
 {% endspaceless %}


### PR DESCRIPTION
I am using this bundle to generate several CKEditor inputs. When I am doing it server-side, all is correct and easy to use. Yet, I have to generate client-side some WYSIWYG textareas, to deal CRUD with Javascript collections.

This PR simply introduces a third variable `rawConfig` for storing server generated configuration. This way, it is far easier to get default configuration as required by `replace` function, based on a pre-existing item. Indeed, the `CKEDITOR.instances["myinstance"].config` is a `prototypedCopy`, which is not valid for `replace` method.
