### PR TITLE
Required can be set to true

### DIFF
--- a/Form/Type/CkeditorType.php
+++ b/Form/Type/CkeditorType.php
@@ -176,7 +176,7 @@ class CkeditorType extends AbstractType
         ));
 
         $resolver->setAllowedValues(array(
-            'required'                 => array(false),
+            'required'                 => array(true, false),
             'startup_outline_blocks'   => array(true, false),
             'force_paste_as_plaintext' => array(true, false),
             'basic_entities'           => array(true, false),


### PR DESCRIPTION
To mark a ckeditor field as required, the "required" option must be set to true. Currently, only "false" is accepted.

Some form theme use this attribute to mark the field as required, such as adding an asterisk prior to the field label.
