### PR TITLE
suggest default configuration for html_purifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ An example configuration:
 trsteel_ckeditor:
     class: Trsteel\CkeditorBundle\Form\Type\CkeditorType
     transformers: ['html_purifier']
+    html_purifier:
+        config: { Cache.SerializerPath: %kernel.cache_dir% }
     toolbar: ['document', 'clipboard', 'editing', '/', 'basicstyles', 'paragraph', 'links', '/', 'insert', 'styles', 'tools']
     toolbar_groups:
         document: ['Source','-','Save','-','Templates']


### PR DESCRIPTION
I spent about an hour trying to figure out why htmlpurifier was trying to write its cache file inside vendor directory. With suggested change, cache directory is configured as default Symfony cache
