### PR TITLE
Remove default required value

### DIFF
--- a/Form/Type/CkeditorType.php
+++ b/Form/Type/CkeditorType.php
@@ -144,7 +144,6 @@ class CkeditorType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
-            'required' => false,
             'transformers' => $this->container->getParameter('trsteel_ckeditor.ckeditor.transformers'),
             'toolbar' => $this->container->getParameter('trsteel_ckeditor.ckeditor.toolbar'),
             'toolbar_groups' => $this->container->getParameter('trsteel_ckeditor.ckeditor.toolbar_groups'),


### PR DESCRIPTION
The default required value should not be false and let the guesser auto guesses.
Linked to #74.