### PR TITLE
Make extraAllowedContent capable of disabling ACF

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -28,7 +28,7 @@
 				templates_files: ['{{ templates_files|join(',')|raw }}'],
             {% endif %}
             {% if extra_allowed_content is not null %}
-                extraAllowedContent: '{{ extra_allowed_content }}',
+                extraAllowedContent: {% if extra_allowed_content != true %}'{{ extra_allowed_content }}'{% else %}true{% endif %},
             {% endif %}
             {% if height is not null %}
                 height: '{{ height }}',


### PR DESCRIPTION
As stated in the official documentation of [CKEditor](http://docs.ckeditor.com/#%21/api/CKEDITOR.config-cfg-allowedContent) one can fully disable the ACF by setting `extraAllowedContent: true` (expecting `true` to be a boolean). With the previous code it would set it to a string `'true'`. This ends in telling CKEditor to allow `<true>` elements which is not what's intended.