### PR TITLE
Fix for extra_allowed_content evaluating to true.

### DIFF
--- a/Resources/views/Form/ckeditor_widget.html.twig
+++ b/Resources/views/Form/ckeditor_widget.html.twig
@@ -32,7 +32,7 @@
                 templates_files: {{ templates_files_array|json_encode }},
             {% endif %}
             {% if extra_allowed_content is not null %}
-                extraAllowedContent: {% if extra_allowed_content != true %}'{{ extra_allowed_content }}'{% else %}true{% endif %},
+                extraAllowedContent: {% if extra_allowed_content is not same as(true) %}'{{ extra_allowed_content }}'{% else %}true{% endif %},
             {% endif %}
             {% if height is not null %}
                 height: '{{ height }}',


### PR DESCRIPTION
In twig, non-empty strings always evaluate to true. So, to check if a variable is true vs. a non-empty string, we need to use a different syntax.

This config:

```yaml
# app/config/config.yml
trsteel_ckeditor:
    extra_allowed_content: "div(*)"
```

Should output:

```javascript
var trsteelConfig = {
    // ...
    extraAllowedContent: 'div(*)',
    // ...
};
````